### PR TITLE
chore: remove `toolchain` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/rootlyhq/rootly-go
 
 go 1.24.0
 
-toolchain go1.24.4
-
 require (
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/oapi-codegen/nullable v1.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,8 +2,6 @@ module github.com/rootlyhq/rootly-go/tools
 
 go 1.22.5
 
-toolchain go1.24.4
-
 require github.com/oapi-codegen/oapi-codegen/v2 v2.5.1
 
 require (


### PR DESCRIPTION
As we don't explicitly require this explicit Go toolchain version to be
used, we shouldn't declare it.
