### PR TITLE
build: periodically update OpenAPI spec

### DIFF
--- a/.github/workflows/update-spec.yml
+++ b/.github/workflows/update-spec.yml
@@ -1,0 +1,51 @@
+name: Update API Spec
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  update-spec:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
+      - name: Fetch latest spec
+        run: make fetch-spec
+
+      - name: Generate code
+        run: make gen
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet '*.go'; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): update OpenAPI spec"
+          branch: chore/deps-openapi-spec
+          title: "chore(deps): update OpenAPI spec"
+          assignees: jamietanna
+          labels: maintenance
+          body: |
+            > [!NOTE]
+            > The CI will not auto-execute due to GitHub Actions not allowing PRs created by `github-actions[bo]` to trigger CI.


### PR DESCRIPTION
To make sure that the OpenAPI spec is updated on a regular basis, we can
add a GitHub Actions workflow to periodically re-fetch the spec, and if
there are changes, raise a PR for the maintainers to take a look.

If the PR is already open, it will be updated.

