### PR TITLE
chore(oapi-codegen): version-pin JSON schema

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/HEAD/configuration-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/v2.5.1/configuration-schema.json
 package: rootly
 output: schema.gen.go
 generate:

--- a/renovate.json
+++ b/renovate.json
@@ -32,5 +32,18 @@
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        ".*/config.yaml$"
+      ],
+      "matchStrings": [
+        "# yaml-language-server: \\$schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/(?<currentValue>[^/]+)/configuration-schema.json"
+      ],
+      "depNameTemplate": "github.com/oapi-codegen/oapi-codegen/v2",
+      "datasourceTemplate": "go"
+    }
   ]
 }


### PR DESCRIPTION
Which we can then automagically update with Renovate as new dependency
updates come out.
