### PR TITLE
chore(renovate): correctly match `config.yaml`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/.*/config.yaml$/"
+        "**/config.yaml"
       ],
       "matchStrings": [
         "# yaml-language-server: \\$schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/(?<currentValue>[^/]+)/configuration-schema.json"


### PR DESCRIPTION
As it's a top-level file, this wasn't matching.
