### PR TITLE
chore(renovate): add `installTools`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,10 @@
         "fileFilters": [
           "**/*.gen.go"
         ],
-        "executionMode": "update"
+        "executionMode": "update",
+        "installTools": {
+          "golang": {}
+        }
       }
     },
     {
@@ -58,7 +61,10 @@
         "fileFilters": [
           "**/*.gen.go"
         ],
-        "executionMode": "update"
+        "executionMode": "update",
+        "installTools": {
+          "golang": {}
+        }
       }
     }
   ],


### PR DESCRIPTION
When Renovate executes our `postUpgradeTasks`, we don't always have the
Go toolchain downloaded, so the task can't complete.

As part of the recently released changes upstream, we can make sure
we're installing the Go toolchain before we run `postUpgradeTasks`.

We don't need to specify a `constraints` at this point, as we should be
safe using the latest Go toolchain (for now).
