### PR TITLE
ci: annotate OpenAPI spec changes with `oasdiff`

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -1,0 +1,60 @@
+name: OpenAPI Diff
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".vendored/rootly-api/swagger.json"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".vendored/rootly-api/swagger.json"
+
+jobs:
+  diff:
+    name: OpenAPI Diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Install oasdiff
+        env:
+          OASDIFF_VERSION: 1.13.1 # renovate: datasource=github-releases depName=oasdiff/oasdiff
+        run: |
+          curl -fsSL -o /tmp/oasdiff.tar.gz \
+            "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/oasdiff.tar.gz -C /usr/local/bin oasdiff
+
+      - name: Get base spec
+        env:
+          PR_BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="$PR_BASE_SHA"
+          else
+            BASE_REF="HEAD~1"
+          fi
+          if git show "${BASE_REF}:.vendored/rootly-api/swagger.json" > /tmp/base-swagger.json 2>/dev/null; then
+            echo "BASE_SPEC_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            echo "BASE_SPEC_EXISTS=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: OpenAPI changelog
+        if: env.BASE_SPEC_EXISTS == 'true'
+        run: |
+          {
+            echo "## OpenAPI Changelog"
+            echo ""
+            oasdiff changelog --format markdown /tmp/base-swagger.json .vendored/rootly-api/swagger.json || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: OpenAPI breaking changes
+        if: env.BASE_SPEC_EXISTS == 'true'
+        run: oasdiff breaking /tmp/base-swagger.json .vendored/rootly-api/swagger.json --format githubactions
+        continue-on-error: true

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,16 @@
       ],
       "depNameTemplate": "github.com/oapi-codegen/oapi-codegen/v2",
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/*.yml",
+        "**/*.yaml"
+      ],
+      "matchStrings": [
+        "\\S+: (?<currentValue>[^\\s#]+)\\s+# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)"
+      ]
     }
   ],
   "vendir": {


### PR DESCRIPTION
To allow us a slightly richer reviewing experience for our OpenAPI spec
updates, we can use `oasdiff` to provide both its changelog and breaking
change detection annotations.

This uses the `oasdiff` CLI itself, rather than relying on an additional
GitHub Action, and outputs to the step summary.

We don't output to the PR itself - for now - as the format needs some
tweaks, first (https://github.com/oasdiff/oasdiff/issues/834).

We can also make sure to version pin `oasdiff` and have Renovate propose
new updates.

---

Example: https://github.com/rootlyhq/rootly-go/actions/runs/24177912616