### PR TITLE
chore(renovate): use upstream Custom Manager + align `minimumReleaseAge`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    "github>oapi-codegen/renovate-config:user"
   ],
   "addLabels": [
     "dependencies"
@@ -73,17 +74,6 @@
     "gomodUpdateImportPaths"
   ],
   "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "**/config.yaml"
-      ],
-      "matchStrings": [
-        "# yaml-language-server: \\$schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/(?<currentValue>[^/]+)/configuration-schema.json"
-      ],
-      "depNameTemplate": "github.com/oapi-codegen/oapi-codegen/v2",
-      "datasourceTemplate": "go"
-    },
     {
       "customType": "regex",
       "managerFilePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "dependencies"
   ],
   "separateMinorPatch": true,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Require human review for `toolchain` directive and Mise updates",
@@ -67,6 +68,12 @@
           "golang": {}
         }
       }
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "7 days"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
As `oapi-codegen` are now providing this Custom Manager upstream, we can
simplify our configuration and use theirs.
