### PR TITLE
chore(renovate): don't set `minimumReleaseAge` on `lockFileMaintenance`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,12 @@
         "major"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "minimumReleaseAge": null
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
As it's unsupported.