### PR TITLE
ci: add a non-integration test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,23 @@ jobs:
         run: go build -v .
 
   test:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Get dependencies
+        run: go mod download
+      - name: Run tests
+        timeout-minutes: 5
+        run: go test -short -v -cover ./...
+
+  integration_test:
     name: Integration Tests
     needs: build
     runs-on: ubuntu-latest

--- a/test/shift_test.go
+++ b/test/shift_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestListShifts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in `short` mode")
+	}
+
 	client := SetupClient(t)
 
 	now := time.Now()


### PR DESCRIPTION
In the past we introduced new test files, but we didn't wire in CI to
run them by default.

To make sure we don't run our integration tests, we can take advantage
of Go's `-short` flag[0].

[0]: https://www.jvt.me/posts/2022/07/01/go-short-test/
