### PR TITLE
test: don't allow deprecations on functions/types

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -136,6 +136,109 @@ func Test_NoDeprecatedUpstreamPropertiesWithoutReason(t *testing.T) {
 	}
 }
 
+// When generating code using `oapi-codegen`, if a type is `deprecated: true`, but no `x-deprecated-reason` is set, we get a `Deprecated: ...` Go Doc comment on the type, but it's not as targeted as we should do
+// To make sure that we're always providing useful deprecation messages for our users, validate that there are no type-level deprecations without `x-deprecated-reason`
+func Test_NoDeprecatedUpstreamTypesWithoutReason(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "schema.gen.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse schema.gen.go: %v", err)
+	}
+
+	const marker = "this type has been marked as deprecated upstream, but no `x-deprecated-reason` was set"
+
+	var failures []string
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		if genDecl.Doc == nil {
+			continue
+		}
+		for _, comment := range genDecl.Doc.List {
+			if strings.Contains(comment.Text, marker) {
+				for _, spec := range genDecl.Specs {
+					typeSpec, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					schemaName := schemaNameFromDoc(genDecl.Doc)
+					if schemaName == "" {
+						schemaName = typeSpec.Name.Name
+					}
+					overlayTarget := "$.components.schemas." + schemaName
+					snippet := fmt.Sprintf(
+						"  - target: %s\n    update:\n      x-deprecated-reason: %q # TODO: amend",
+						overlayTarget, "",
+					)
+					failures = append(failures, snippet)
+				}
+				break
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Errorf("schema.gen.go contains %d deprecated types without an x-deprecated-reason.\nAdd the following to overlay.yaml:\n\n%s\n",
+			len(failures), strings.Join(failures, "\n\n"))
+	}
+}
+
+// When generating code using `oapi-codegen`, if an operation is `deprecated: true`, but no `x-deprecated-reason` is set, we get a `Deprecated: ...` Go Doc comment on the interface method, but it's not as targeted as we should do
+// To make sure that we're always providing useful deprecation messages for our users, validate that there are no operation-level deprecations without `x-deprecated-reason`
+func Test_NoDeprecatedUpstreamOperationsWithoutReason(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "schema.gen.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse schema.gen.go: %v", err)
+	}
+
+	const marker = "this operation has been marked as deprecated upstream, but no `x-deprecated-reason` was set"
+
+	var failures []string
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			iface, ok := typeSpec.Type.(*ast.InterfaceType)
+			if !ok {
+				continue
+			}
+			for _, method := range iface.Methods.List {
+				if method.Doc == nil {
+					continue
+				}
+				for _, comment := range method.Doc.List {
+					if strings.Contains(comment.Text, marker) {
+						methodName := "(unknown)"
+						if len(method.Names) > 0 {
+							methodName = method.Names[0].Name
+						}
+						snippet := fmt.Sprintf(
+							"  - # method: %s\n    target: \"$.paths['TODO'].TODO\"\n    update:\n      x-deprecated-reason: %q # TODO: amend",
+							methodName, "",
+						)
+						failures = append(failures, snippet)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Errorf("schema.gen.go contains %d deprecated operations without an x-deprecated-reason.\nAdd the following to overlay.yaml (filling in the correct path and HTTP method):\n\n%s\n",
+			len(failures), strings.Join(failures, "\n\n"))
+	}
+}
+
 // https://github.com/rootlyhq/rootly-go/issues/39
 func Test_OptionalQueryParameterIsNotSerializedIntoURL(t *testing.T) {
 	params := ListShiftsParams{


### PR DESCRIPTION
As part of future changes upstream in `oapi-codegen` (https://github.com/oapi-codegen/oapi-codegen/pull/2405), we'll have some
deprecations found on our generated types/functions, which we should
validate similar to 2976576eaf528cdb460e28609a26044d8086a406.

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@rootly.com>
