### PR TITLE
ci: fail CI on breaking changes

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -279,4 +279,4 @@ jobs:
 
       - name: OpenAPI overlay breaking changes
         if: env.BASE_SPEC_EXISTS == 'true'
-        run: oasdiff breaking /tmp/base-overlay-applied.json /tmp/pr-overlay-applied.json --format githubactions
+        run: oasdiff breaking /tmp/base-overlay-applied.json /tmp/pr-overlay-applied.json --format githubactions --fail-on ERR


### PR DESCRIPTION
As a follow-up to https://github.com/rootlyhq/rootly-go/pull/122, we should
make sure that `oasdiff` actually fails.